### PR TITLE
Fix/added-death-screen

### DIFF
--- a/Assets/Scenes/Firstviablegame 1.unity
+++ b/Assets/Scenes/Firstviablegame 1.unity
@@ -605,6 +605,7 @@ MonoBehaviour:
   startingHealth: 0
   iFramesDuration: 0
   numberOfFlashes: 0
+  gameOverScreen: {fileID: 0}
 --- !u!1 &87971850
 GameObject:
   m_ObjectHideFlags: 0
@@ -1291,7 +1292,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &429823683
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5129,6 +5130,7 @@ MonoBehaviour:
   startingHealth: 3
   iFramesDuration: 0
   numberOfFlashes: 0
+  gameOverScreen: {fileID: 429823682}
 --- !u!82 &1557351975
 AudioSource:
   m_ObjectHideFlags: 0
@@ -6164,6 +6166,7 @@ MonoBehaviour:
   startingHealth: 3
   iFramesDuration: 0
   numberOfFlashes: 0
+  gameOverScreen: {fileID: 0}
 --- !u!1 &1994030010
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -16,11 +16,16 @@ public class Health : MonoBehaviour
     [SerializeField] private int numberOfFlashes;
     private SpriteRenderer spriteRend;
 
+    // Code for Game over screen
+    [Header("Gameover")]
+    [SerializeField] public GameObject gameOverScreen;
+
     private void Awake()
     {
         currentHealth = startingHealth;
         anim = GetComponent<Animator>();
         spriteRend = GetComponent<SpriteRenderer>();
+        gameOverScreen.SetActive(false);
     }
 
     public void TakeDamage(float _damage)
@@ -39,6 +44,9 @@ public class Health : MonoBehaviour
             {
                 anim.SetTrigger("Die");
                 Debug.Log("Dog has no lives (dead)");
+                
+                GameOver(true);
+
 
                 if (GetComponentInParent<playerController>() != null)
                 {
@@ -88,5 +96,17 @@ public class Health : MonoBehaviour
             TakeDamage(1);
         }
         
+    }
+
+// Code below is for the death screen and a 2 second delay.
+    public void GameOver(bool status)
+    {   
+        StartCoroutine(GameOverWithDelay(status, 2f));
+    }
+
+    private IEnumerator GameOverWithDelay(bool status, float delay)
+    {
+        yield return new WaitForSeconds(delay);
+        gameOverScreen.SetActive(status);
     }
 }


### PR DESCRIPTION
I have added the death screen when the health depletes. I put in a 2 second delay so we can see the animation of the dog laying down. I am still getting the error
 'UnassignedReferenceException: The variable gameOverScreen of Health has not been assigned.
You probably need to assign the gameOverScreen variable of the Health script in the inspector. Health.Awake () (at Assets/Scripts/Health.cs:28)'

Closes #81 