### PR TITLE
Fix/gameOverScreen-variable-error

### DIFF
--- a/Assets/Scenes/Firstviablegame 1.unity
+++ b/Assets/Scenes/Firstviablegame 1.unity
@@ -605,7 +605,7 @@ MonoBehaviour:
   startingHealth: 0
   iFramesDuration: 0
   numberOfFlashes: 0
-  gameOverScreen: {fileID: 0}
+  gameOverScreen: {fileID: 429823682}
 --- !u!1 &87971850
 GameObject:
   m_ObjectHideFlags: 0
@@ -6166,7 +6166,7 @@ MonoBehaviour:
   startingHealth: 3
   iFramesDuration: 0
   numberOfFlashes: 0
-  gameOverScreen: {fileID: 0}
+  gameOverScreen: {fileID: 429823682}
 --- !u!1 &1994030010
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
I have fixed the game over screen missing variable code. the code is used in enemy and hitstomp, so it had to be assigned here as well.
Closes #81 